### PR TITLE
Update __init__.py

### DIFF
--- a/signify/authenticode/__init__.py
+++ b/signify/authenticode/__init__.py
@@ -1,5 +1,6 @@
 from .authroot import AUTHROOTSTL_PATH, CertificateTrustList, CertificateTrustSubject
 from .signed_pe import SignedPEFile
+from .signed_msi import SignedMsiFile
 from .structures import (
     CERTIFICATE_LOCATION,
     TRUSTED_CERTIFICATE_STORE,
@@ -29,5 +30,6 @@ __all__ = [
     "RFC3161SignedData",
     "RFC3161SignerInfo",
     "SignedPEFile",
+    "SignedMsiFile",
     "TSTInfo",
 ]


### PR DESCRIPTION
During my review of the MSI addition to signify, I identified that SignedMsiFile was not imported as part of the __init__.py . 
I think this may have been intentional with the MSI option being optional. (?) If not, it seemed good to highlight the need for it to be in the __init__.py in some situations. (Without it being in the __init__.py, I found it confusing and not intuitive as to how to use the SignedMsiFile method.)

Perhaps there are other methods you are using to call the SignedMsiFile method, but, for my uses, I duplicated the original test use file "[authenticode_info.py](https://github.com/ralphje/signify/blob/master/examples/authenticode_info.py)" in order to print and display the authenticode information from an MSI file. 

Right now, I have it as a separate script (I can share if desired) but I will likely integrate it into the authenticode_info.py script so that the same script works for both EXE or MSI.